### PR TITLE
Vectors rework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,21 +71,41 @@ FILES =	$(FILES_PATH)main \
 
 CFILES = $(FILES:%=%.c)
 
-FILES_TEST = $(FILES_PATH)main_test \
-			 $(FILES_PATH)miniRT \
-			 $(FILES_PATH)camera/camera \
-			 $(FILES_PATH)camera/image \
-			 $(FILES_PATH)exit_handler/exit_handler_$(OS) \
-			 $(FILES_PATH)objects/objects \
-			 $(FILES_PATH)objects/sphere \
-			 $(FILES_PATH)objects/plane \
-			 $(FILES_PATH)rays/rays \
-			 $(FILES_PATH)vectors/vectors_instance \
-			 $(FILES_PATH)vectors/vectors_operations \
-			 $(FILES_PATH)vectors/vectors_products \
-			 $(FILES_PATH)vectors/vectors_properties \
-			 $(FILES_PATH)color/color \
-			 $(FILES_PATH)color/color_operations \
+FILES_TEST =	$(FILES_PATH)main_test \
+		$(FILES_PATH)miniRT \
+		$(FILES_PATH)camera/camera \
+		$(FILES_PATH)camera/image \
+		$(FILES_PATH)exit_handler/exit_handler_$(OS) \
+		$(FILES_PATH)objects/objects \
+		$(FILES_PATH)objects/sphere \
+		$(FILES_PATH)objects/plane \
+		$(FILES_PATH)rays/rays \
+		$(FILES_PATH)vectors/vectors_instance \
+		$(FILES_PATH)vectors/vectors_operations \
+		$(FILES_PATH)vectors/vectors_products \
+		$(FILES_PATH)vectors/vectors_properties \
+		$(FILES_PATH)color/color \
+		$(FILES_PATH)color/color_operations \
+		$(FILES_PATH)generator/rt_generator \
+		$(FILES_PATH)generator/rt_generate_nbr \
+		$(FILES_PATH)generator/rt_generate_scene \
+		$(FILES_PATH)generator/rt_generator_obj \
+		$(FILES_PATH)utils/ft_split_sp_tab \
+		$(FILES_PATH)utils/ft_strlen_tab \
+		$(FILES_PATH)parsing/error_handling \
+		$(FILES_PATH)utils/ft_atof \
+		$(FILES_PATH)parsing/parsing \
+		$(FILES_PATH)parsing/get_amb \
+		$(FILES_PATH)parsing/get_cam \
+		$(FILES_PATH)parsing/get_obj \
+		$(FILES_PATH)parsing/get_size \
+		$(FILES_PATH)parsing/obj_cy \
+		$(FILES_PATH)parsing/obj_lig \
+		$(FILES_PATH)parsing/obj_pl \
+		$(FILES_PATH)parsing/obj_sp \
+		$(FILES_PATH)parsing/only_function \
+		$(FILES_PATH)parsing/check_range_format \
+		$(FILES_PATH)parsing/print_token
 
 CFILES_TEST = $(FILES_TEST:%=%.c)
 
@@ -106,7 +126,7 @@ re :
 	@make all
 
 test : $(CFILES_TEST) $(LIBFT_LIB) $(MINILIBX_LIB)
-	@$(CC) $(CFILES_TEST) $(LIBFT_LIB) $(MINILIBX_LIB) $(CFLAGS) -o $(NAME)
+	@$(CC) $(CFILES_TEST) $(LIBFT_LIB) $(MINILIBX_LIB) $(CFLAGS) -g -o $(NAME) -D DEBUG=1
 	@echo " \t$(NAME) test compiled ✅"
 
 debug : $(CFILES) $(LIBFT_LIB) $(MINILIBX_LIB)

--- a/libs/betterft/Makefile
+++ b/libs/betterft/Makefile
@@ -86,6 +86,7 @@ FILES = ft_atoi \
 		garbage_collector \
 		garbage_utils \
 		ft_joint_all \
+		ft_equals \
 
 SECURED_FILES = $(FILES) garbage_galloc_secure
 UNSECURED_FILES = $(FILES) garbage_galloc

--- a/libs/betterft/betterft.h
+++ b/libs/betterft/betterft.h
@@ -318,7 +318,17 @@ char		*ft_memtostr(void *mem, size_t size);
 //	array of strings.
 //	Each string in the array must have been allocated dynamically.
 int			ft_free_tab(char **tab);
-// Split all string of **str and return a char * joind by all the string.
+//	ft_joint_all: Concatenates all strings in the null-terminated array 'str'
+//	into a new dynamically allocated string.
+//	Returns the resulting string.
 char		*ft_joint_all(char **str);
+//	ft_equalsf: Compares two floating-point numbers 'a' and 'b' with a
+//	fixed epsilon value of 0.00001f.
+//	Returns true if the difference between 'a' and 'b' is less than the epsilon.
+bool		ft_equalsf(float a, float b);
+//	ft_equalsd: Compares two double-precision floating-point numbers 'a' and 'b'
+//	with a fixed epsilon value of 0.0000000001.
+//	Returns true if the difference between 'a' and 'b' is less than the epsilon.
+bool		ft_equalsd(double a, double b);
 
 #endif

--- a/libs/betterft/src/ft_equals.c
+++ b/libs/betterft/src/ft_equals.c
@@ -1,0 +1,23 @@
+#include "../betterft.h"
+
+bool	ft_equalsf(float a, float b)
+{
+	const float	EPSILON = 0.00001f;
+	float		diff;
+
+	diff = a - b;
+	if (diff < 0)
+		diff = -diff;
+	return (diff < EPSILON);
+}
+
+bool	ft_equalsd(double a, double b)
+{
+	const double	EPSILON = 0.0000000001;
+	double			diff;
+
+	diff = a - b;
+	if (diff < 0)
+		diff = -diff;
+	return (diff < EPSILON);
+}

--- a/src/camera/camera.c
+++ b/src/camera/camera.c
@@ -24,7 +24,7 @@ t_ray	make_ray(t_camera *camera, t_vector2 point)
 {
 	t_vector3	direction;
 
-	direction = vadd(vadd(camera->forward, vmul(camera->right, point.u
-					* camera->w)), vmul(camera->up, point.v * camera->h));
+	direction = vadd(vadd(camera->forward, vmul(camera->right, point.x
+					* camera->w)), vmul(camera->up, point.y * camera->h));
 	return (ray(camera->origin, vnormalized(direction)));
 }

--- a/src/main_test.c
+++ b/src/main_test.c
@@ -22,6 +22,9 @@ int	main(void)
 	ft_lstpush(scene, new_sphere(point3(0, 0, -2.8), 1.5, color(0, 255, 0)));
 	ray_trace(image, camera, scene);
 	t_minirt	minirt;
+	minirt.size = galloc(sizeof(t_image));
+	minirt.size->height = HEIGHT;
+	minirt.size->width = WIDTH;
 	init_minirt_mlx(&minirt);
 	for (int i = 0; i < WIDTH; i++)
 	{

--- a/src/vectors/vectors.h
+++ b/src/vectors/vectors.h
@@ -51,44 +51,44 @@ t_vector3	vector3(double x, double y, double z);
 //	@return A new 3D point
 t_point3	point3(double x, double y, double z);
 
-//	vlength: Get the length of a vector
+//	vlength: Get the length (magnitude) of a vector
 //	@param v The vector
 //	@return The length of the vector
 double		vlength(t_vector3 v);
 
-//	vlength2: Get the squared length of a vector
+//	vlength2: Get the squared length (magnitude) of a vector
 //	@param v The vector
 //	@return The squared length of the vector
 double		vlength2(t_vector3 v);
 
-//	vadd: Add two vectors
-//	@param v The first vector
-//	@param u The second vector
-//	@return The sum of the two vectors
-t_vector3	vadd(t_vector3 v, t_vector3 u);
+//	vadd: Add two tuples
+//	@param v The first tuple
+//	@param u The second tuple
+//	@return The sum of the two tuples
+t_tuple4	vadd(t_tuple4 v, t_tuple4 u);
 
-//	vsub: Subtract two vectors
-//	@param v The first vector
-//	@param u The second vector
-//	@return The difference of the two vectors
-t_vector3	vsub(t_vector3 v, t_vector3 u);
+//	vsub: Subtract two tuples
+//	@param v The first tuple
+//	@param u The second tuple
+//	@return The difference of the two tuples
+t_tuple4	vsub(t_tuple4 v, t_tuple4 u);
 
-//	vmul: Multiply a vector by a scalar
-//	@param v The vector
+//	vmul: Multiply a tuple by a scalar
+//	@param v The tuple
 //	@param scalar The scalar
-//	@return The product of the vector and the scalar
-t_vector3	vmul(t_vector3 v, double scalar);
+//	@return The product of the tuple and the scalar
+t_tuple4	vmul(t_tuple4 v, double scalar);
 
-//	vdiv: Divide a vector by a scalar
-//	@param v The vector
+//	vdiv: Divide a tuple by a scalar
+//	@param v The tuple
 //	@param scalar The scalar
-//	@return The quotient of the vector and the scalar
-t_vector3	vdiv(t_vector3 v, double scalar);
+//	@return The quotient of the tuple and the scalar
+t_tuple4	vdiv(t_tuple4 v, double scalar);
 
-//	vneg: Negate a vector
-//	@param v The vector
-//	@return The negated vector
-t_vector3	vneg(t_vector3 v);
+//	vneg: Negate a tuple
+//	@param v The tuple
+//	@return The negated tuple
+t_tuple4	vneg(t_tuple4 v);
 
 //	vdot: Get the dot product of two vectors
 //	@param v The first vector

--- a/src/vectors/vectors.h
+++ b/src/vectors/vectors.h
@@ -8,20 +8,28 @@
 #  define M_PI 3.14159265358979323846f
 # endif
 
-typedef struct s_vector2
-{
-	double	u;
-	double	v;
-}	t_vector2;
+# ifndef DEBUG
+#  define DEBUG 0
+# endif
 
-typedef struct s_vector3
+# define VECTOR	0.0
+# define POINT	1.0
+
+typedef struct s_tuple4
 {
 	double	x;
 	double	y;
 	double	z;
-}	t_vector3;
+	double	w;
+}	t_tuple4;
 
-typedef t_vector3	t_point3;
+typedef t_tuple4	t_vector3;
+
+typedef t_tuple4	t_point3;
+
+typedef t_tuple4	t_vector2;
+
+typedef t_tuple4	t_point2;
 
 //	vector2: Create a new 2D vector
 //	@param u The u component
@@ -76,6 +84,11 @@ t_vector3	vmul(t_vector3 v, double scalar);
 //	@param scalar The scalar
 //	@return The quotient of the vector and the scalar
 t_vector3	vdiv(t_vector3 v, double scalar);
+
+//	vneg: Negate a vector
+//	@param v The vector
+//	@return The negated vector
+t_vector3	vneg(t_vector3 v);
 
 //	vdot: Get the dot product of two vectors
 //	@param v The first vector

--- a/src/vectors/vectors_instance.c
+++ b/src/vectors/vectors_instance.c
@@ -1,25 +1,26 @@
 #include "vectors.h"
 
+t_tuple4	tuple4(double x, double y, double z, double w)
+{
+	return ((t_tuple4){.x = x, .y = y, .z = z, .w = w});
+}
+
 t_vector3	vector3(double x, double y, double z)
 {
-	t_vector3	vector;
-
-	vector.x = x;
-	vector.y = y;
-	vector.z = z;
-	return (vector);
+	return (tuple4(x, y, z, VECTOR));
 }
 
 t_point3	point3(double x, double y, double z)
 {
-	return (vector3(x, y, z));
+	return (tuple4(x, y, z, POINT));
 }
 
 t_vector2	vector2(double u, double v)
 {
-	t_vector2	vector;
+	return (tuple4(u, v, 0, VECTOR));
+}
 
-	vector.u = u;
-	vector.v = v;
-	return (vector);
+t_point2	point2(double u, double v)
+{
+	return (tuple4(u, v, 0, POINT));
 }

--- a/src/vectors/vectors_operations.c
+++ b/src/vectors/vectors_operations.c
@@ -1,30 +1,30 @@
 #include "vectors.h"
 
-t_vector3	vadd(t_vector3 v, t_vector3 u)
+t_tuple4	vadd(t_tuple4 v, t_tuple4 u)
 {
 	if (DEBUG && u.w == POINT && v.w == POINT)
 		printf("Warning: Adding two points\n");
-	return ((t_vector3){v.x + u.x, v.y + u.y, v.z + u.z, v.w + u.w});
+	return ((t_tuple4){v.x + u.x, v.y + u.y, v.z + u.z, v.w + u.w});
 }
 
-t_vector3	vsub(t_vector3 v, t_vector3 u)
+t_tuple4	vsub(t_tuple4 v, t_tuple4 u)
 {
 	if (DEBUG && u.w == VECTOR && v.w == POINT)
 		printf("Warning: Subtracting a point from a vector\n");
-	return ((t_vector3){v.x - u.x, v.y - u.y, v.z - u.z, v.w - u.w});
+	return ((t_tuple4){v.x - u.x, v.y - u.y, v.z - u.z, v.w - u.w});
 }
 
-t_vector3	vmul(t_vector3 v, double scalar)
+t_tuple4	vneg(t_tuple4 v)
 {
-	return ((t_vector3){v.x * scalar, v.y * scalar, v.z * scalar, v.w});
+	return ((t_tuple4){-v.x, -v.y, -v.z, -v.w});
 }
 
-t_vector3	vneg(t_vector3 v)
+t_tuple4	vmul(t_tuple4 v, double scalar)
 {
-	return ((t_vector3){-v.x, -v.y, -v.z, v.w});
+	return ((t_tuple4){v.x * scalar, v.y * scalar, v.z * scalar, v.w});
 }
 
-t_vector3	vdiv(t_vector3 v, double scalar)
+t_tuple4	vdiv(t_tuple4 v, double scalar)
 {
-	return ((t_vector3){v.x / scalar, v.y / scalar, v.z / scalar, v.w});
+	return ((t_tuple4){v.x / scalar, v.y / scalar, v.z / scalar, v.w});
 }

--- a/src/vectors/vectors_operations.c
+++ b/src/vectors/vectors_operations.c
@@ -2,20 +2,29 @@
 
 t_vector3	vadd(t_vector3 v, t_vector3 u)
 {
-	return ((t_vector3){v.x + u.x, v.y + u.y, v.z + u.z});
+	if (DEBUG && u.w == POINT && v.w == POINT)
+		printf("Warning: Adding two points\n");
+	return ((t_vector3){v.x + u.x, v.y + u.y, v.z + u.z, v.w + u.w});
 }
 
 t_vector3	vsub(t_vector3 v, t_vector3 u)
 {
-	return ((t_vector3){v.x - u.x, v.y - u.y, v.z - u.z});
+	if (DEBUG && u.w == VECTOR && v.w == POINT)
+		printf("Warning: Subtracting a point from a vector\n");
+	return ((t_vector3){v.x - u.x, v.y - u.y, v.z - u.z, v.w - u.w});
 }
 
 t_vector3	vmul(t_vector3 v, double scalar)
 {
-	return ((t_vector3){v.x * scalar, v.y * scalar, v.z * scalar});
+	return ((t_vector3){v.x * scalar, v.y * scalar, v.z * scalar, v.w});
+}
+
+t_vector3	vneg(t_vector3 v)
+{
+	return ((t_vector3){-v.x, -v.y, -v.z, v.w});
 }
 
 t_vector3	vdiv(t_vector3 v, double scalar)
 {
-	return ((t_vector3){v.x / scalar, v.y / scalar, v.z / scalar});
+	return ((t_vector3){v.x / scalar, v.y / scalar, v.z / scalar, v.w});
 }

--- a/src/vectors/vectors_products.c
+++ b/src/vectors/vectors_products.c
@@ -2,14 +2,19 @@
 
 double	vdot(t_vector3 v, t_vector3 u)
 {
-	return (v.x * u.x + v.y * u.y + v.z * u.z);
+	if (DEBUG && (v.w == POINT || u.w == POINT))
+		printf("Warning: Getting the dot product of a point\n");
+	return (v.x * u.x + v.y * u.y + v.z * u.z + v.w * u.w);
 }
 
 t_vector3	vcross(t_vector3 v, t_vector3 u)
 {
-	return ((t_vector3){
-		v.y * u.z - v.z * u.y,
-		v.z * u.x - v.x * u.z,
-		v.x * u.y - v.y * u.x
-	});
+	if (DEBUG && (v.w == POINT || u.w == POINT))
+		printf("Warning: Getting the cross product of a point\n");
+	return (vector3(
+			v.y * u.z - v.z * u.y,
+			v.z * u.x - v.x * u.z,
+			v.x * u.y - v.y * u.x
+		)
+	);
 }

--- a/src/vectors/vectors_properties.c
+++ b/src/vectors/vectors_properties.c
@@ -2,26 +2,28 @@
 
 double	vlength2(t_vector3 v)
 {
+	if (DEBUG && v.w == POINT)
+		printf("Warning: Getting the squared length of a point\n");
 	return (v.x * v.x + v.y * v.y + v.z * v.z);
 }
 
 double	vlength(t_vector3 v)
 {
+	if (DEBUG && v.w == POINT)
+		printf("Warning: Getting the length of a point\n");
 	return (sqrt(vlength2(v)));
 }
 
 t_vector3	vnormalized(t_vector3 v)
 {
+	if (DEBUG && v.w == POINT)
+		printf("Warning: Normalizing a point\n");
 	return (vdiv(v, vlength(v)));
 }
 
 t_vector3	*vnormalize(t_vector3 *v)
 {
-	t_vector3	norm;
-
-	norm = vnormalized(*v);
-	v->x = norm.x;
-	v->y = norm.y;
-	v->z = norm.z;
-	return (v);
+	if (DEBUG && v->w == POINT)
+		printf("Warning: Normalizing a point\n");
+	*v = vdiv(*v, vlength(*v));
 }

--- a/src/vectors/vectors_properties.c
+++ b/src/vectors/vectors_properties.c
@@ -26,4 +26,5 @@ t_vector3	*vnormalize(t_vector3 *v)
 	if (DEBUG && v->w == POINT)
 		printf("Warning: Normalizing a point\n");
 	*v = vdiv(*v, vlength(*v));
+	return (v);
 }


### PR DESCRIPTION
Refactored vectors.h to use four-dimensional vectors (tuples) as the base, instead of three-dimensional vectors. This adjustment guarantees that initializations with vector3(), point3(), etc., will not require any changes.

Introduced ft_equalsf and ft_equalsd functions that use an epsilon for greater tolerance in floating-point precision.

Updated main_test to be compatible with the vectors rework.