### PR TITLE
Render rework

### DIFF
--- a/src/camera/image.c
+++ b/src/camera/image.c
@@ -1,38 +1,13 @@
 #include "image.h"
 
-static t_image	*allocate_image(t_image *image)
-{
-	int	i;
-
-	i = -1;
-	while (i++, i < image->height)
-	{
-		image->data[i] = galloc(sizeof(int) * image->width);
-		if (!image->data[i])
-		{
-			while (i--)
-				gfree(image->data[i]);
-			gfree(image->data);
-			return (0);
-		}
-	}
-	return (image);
-}
-
 t_image	*new_image(int width, int height)
 {
-	t_image	*image;
+	t_image		*image;
 
-	image = galloc(sizeof(t_image));
+	image = ft_calloc(1, sizeof(t_image));
 	if (!image)
 		return (0);
 	image->width = width;
 	image->height = height;
-	image->data = galloc(sizeof(int *) * height);
-	if (!image->data)
-	{
-		gfree(image);
-		return (0);
-	}
-	return (allocate_image(image));
+	return (image);
 }

--- a/src/camera/image.h
+++ b/src/camera/image.h
@@ -8,7 +8,7 @@ typedef struct s_image
 {
 	int		width;
 	int		height;
-	int		**data;
+	void	*mlx_img;
 }	t_image;
 
 typedef struct s_size

--- a/src/camera/render.c
+++ b/src/camera/render.c
@@ -11,43 +11,38 @@ void	pixelate(t_image *image, t_color color, int x, int y)
 	{
 		j = -1;
 		while (++j, j <= PREVIEW_PIXEL_SIZE && x + j < image->width)
-			image->data[y + i][x + j] = color_hex(color);
+			put_pixel_to_image(image->mlx_img, x + j, y + i, color_hex(color));
 	}
 }
 
 void	put_pixel_to_image(void *img, int x, int y, int color)
 {
-	char	*data;
-	int		bpp;
-	int		size_line;
-	int		endian;
-	int		bppd;
+	static char	*data;
+	static int	bpp;
+	static int	size_line;
+	static int	endian;
+	static int	bppd;
 
-	data = mlx_get_data_addr(img, &bpp, &size_line, &endian);
-	bppd = bpp >> 3;
+	if (!data)
+	{
+		data = mlx_get_data_addr(img, &bpp, &size_line, &endian);
+		bppd = bpp >> 3;
+	}
+	if (x < 0 || x >= get_minirt()->size->width
+		|| y < 0 || y >= get_minirt()->size->height)
+		return ;
+	color = mlx_get_color_value(get_minirt()->win.mlx, color);
 	*(int *)(data + (y * size_line + x * bppd)) = color;
 }
 
 void	display(void)
 {
 	t_minirt	*minirt;
-	void		*img;
-	int			i;
-	int			j;
 
 	minirt = get_minirt();
-	img = mlx_new_image(minirt->win.mlx,
-			minirt->size->width, minirt->size->height);
-	i = -1;
-	while (++i < minirt->size->height)
-	{
-		j = -1;
-		while (++j < minirt->size->width)
-			put_pixel_to_image(img, j, i, minirt->size->data[i][j]);
-	}
-	mlx_put_image_to_window(minirt->win.mlx, minirt->win.windo, img, 0, 0);
+	mlx_put_image_to_window(minirt->win.mlx, minirt->win.windo,
+		minirt->size->mlx_img, 0, 0);
 	mlx_do_sync(minirt->win.mlx);
-	mlx_destroy_image(minirt->win.mlx, img);
 }
 
 void	fast_render(void)
@@ -100,8 +95,8 @@ void	render(void)
 		{
 			if (!(++percent[0] % 100000))
 				print_percent(ft_itoa((percent[0] * 100) / percent[1]));
-			minirt->size->data[y][x] = color_hex(color_at(
-						ray_for_pixel(minirt->cam, x, y), false, MAX_REFLECT));
+			put_pixel_to_image(minirt->size->mlx_img, x, y, color_hex(color_at(
+						ray_for_pixel(minirt->cam, x, y), false, MAX_REFLECT)));
 		}
 	}
 	display();

--- a/src/camera/render.h
+++ b/src/camera/render.h
@@ -4,7 +4,7 @@
 # include "camera.h"
 # include "image.h"
 
-# define MAX_REFLECT 5
+# define MAX_REFLECT 10
 # define PREVIEW_PIXEL_SIZE 7
 
 //	pixelate: Pixelate the image

--- a/src/compute/compute.c
+++ b/src/compute/compute.c
@@ -106,7 +106,7 @@ t_color	color_at(t_ray r, bool fast, int remaining)
 	t_minirt	*minirt;
 
 	if (fast && remaining >= MAX_REFLECT)
-		remaining = MAX_REFLECT - 1;
+		remaining = 1;
 	minirt = get_minirt();
 	xs_parent = intersect_world(minirt->scene, r);
 	i = hit(xs_parent);

--- a/src/compute/lightning.c
+++ b/src/compute/lightning.c
@@ -48,8 +48,8 @@ t_color	lightning(t_object *obj, t_lightning ln, bool in_shadow, bool fast)
 
 	(void)fast;
 	if (obj->mat.pattern.has_pattern)
-		obj->mat.color = obj->mat.pattern.pattern_at_object(obj->mat.pattern,
-				obj, ln.p);
+		obj->mat.color = obj->mat.pattern
+			.pattern_at_object(obj->mat.pattern, obj, ln.p);
 	eff_color = color_mult(obj->mat.color, ((t_light *)(ln.l->data))->c_rgb);
 	c[0] = color_mult(ambience(ln.amb), eff_color);
 	if (in_shadow)

--- a/src/exit_handler/exit_handler_linux.c
+++ b/src/exit_handler/exit_handler_linux.c
@@ -6,16 +6,12 @@ void	free_object(void *object)
 	gfree(object);
 }
 
-static void	clear_image(t_image *image)
+static void	clear_image(t_minirt *minirt, t_image *image)
 {
-	int	i;
-
-	i = -1;
-	if (image->data)
-		while (++i < image->height)
-			gfree(image->data[i]);
-	if (image->data)
-		gfree(image->data);
+	if (image->mlx_img)
+		mlx_destroy_image(minirt->win.mlx, image->mlx_img);
+	if (image->mlx_img)
+		gfree(image->mlx_img);
 	gfree(image);
 }
 
@@ -28,7 +24,7 @@ void	clear_memory(t_minirt *minirt)
 	if (minirt && minirt->win.mlx)
 		gfree(minirt->win.mlx);
 	if (minirt && minirt->size)
-		clear_image(minirt->size);
+		clear_image(minirt, minirt->size);
 	if (minirt && minirt->amb)
 		gfree(minirt->amb);
 	if (minirt && minirt->cam)

--- a/src/exit_handler/exit_handler_linux.c
+++ b/src/exit_handler/exit_handler_linux.c
@@ -10,21 +10,19 @@ static void	clear_image(t_minirt *minirt, t_image *image)
 {
 	if (image->mlx_img)
 		mlx_destroy_image(minirt->win.mlx, image->mlx_img);
-	if (image->mlx_img)
-		gfree(image->mlx_img);
 	gfree(image);
 }
 
 void	clear_memory(t_minirt *minirt)
 {
+	if (minirt && minirt->size)
+		clear_image(minirt, minirt->size);
 	if (minirt && minirt->win.mlx && minirt->win.windo)
 		mlx_destroy_window(minirt->win.mlx, minirt->win.windo);
 	if (minirt && minirt->win.mlx)
 		mlx_destroy_display(minirt->win.mlx);
 	if (minirt && minirt->win.mlx)
 		gfree(minirt->win.mlx);
-	if (minirt && minirt->size)
-		clear_image(minirt, minirt->size);
 	if (minirt && minirt->amb)
 		gfree(minirt->amb);
 	if (minirt && minirt->cam)

--- a/src/exit_handler/exit_handler_macos.c
+++ b/src/exit_handler/exit_handler_macos.c
@@ -27,12 +27,12 @@ static void	clear_image(t_minirt *minirt, t_image *image)
 
 void	clear_memory(t_minirt *minirt)
 {
+	if (minirt && minirt->size)
+		clear_image(minirt, minirt->size);
 	if (minirt && minirt->win.mlx)
 		mlx_destroy_window(minirt->win.mlx, minirt->win.windo);
 	if (minirt && minirt->win.mlx)
 		gfree(minirt->win.mlx);
-	if (minirt && minirt->size)
-		clear_image(minirt, minirt->size);
 	if (minirt && minirt->amb)
 		gfree(minirt->amb);
 	if (minirt && minirt->cam)

--- a/src/exit_handler/exit_handler_macos.c
+++ b/src/exit_handler/exit_handler_macos.c
@@ -16,16 +16,12 @@ void	free_object(void *object)
 	gfree(object);
 }
 
-static void	clear_image(t_image *image)
+static void	clear_image(t_minirt *minirt, t_image *image)
 {
-	int	i;
-
-	i = -1;
-	if (image->data)
-		while (++i < image->height)
-			gfree(image->data[i]);
-	if (image->data)
-		gfree(image->data);
+	if (image->mlx_img)
+		mlx_destroy_image(minirt->win.mlx, image->mlx_img);
+	if (image->mlx_img)
+		gfree(image->mlx_img);
 	gfree(image);
 }
 
@@ -36,7 +32,7 @@ void	clear_memory(t_minirt *minirt)
 	if (minirt && minirt->win.mlx)
 		gfree(minirt->win.mlx);
 	if (minirt && minirt->size)
-		clear_image(minirt->size);
+		clear_image(minirt, minirt->size);
 	if (minirt && minirt->amb)
 		gfree(minirt->amb);
 	if (minirt && minirt->cam)

--- a/src/miniRT.c
+++ b/src/miniRT.c
@@ -52,6 +52,10 @@ void	*init_minirt_mlx(t_minirt *minirt)
 			minirt->size->height, "miniRT");
 	if (!minirt->win.windo)
 		crash_exit(minirt, NULL, "windo malloc fail");
+	minirt->size->mlx_img = mlx_new_image(minirt->win.mlx,
+			minirt->size->width, minirt->size->height);
+	if (!minirt->size->mlx_img)
+		crash_exit(minirt, NULL, "mlx image malloc fail");
 	mlx_hook(minirt->win.windo, 17, 0, secure_exit, minirt);
 	mlx_hook(minirt->win.windo, 2, 1L << 0, handle_key, minirt);
 	mlx_loop_hook(minirt->win.mlx, loop_hook, minirt);

--- a/src/objects/patterns.c
+++ b/src/objects/patterns.c
@@ -27,29 +27,22 @@ t_pattern	stripe_pattern(t_color a, t_color b)
 		.has_pattern = true, .transform = m4default()});
 }
 
-static t_color	gradient_at_object(t_pattern pattern,
-					void *object, t_point3 point)
+static t_color
+	checkboard_at_object(t_pattern pattern, void *object, t_point3 point)
 {
 	t_point3	obj_point;
 	t_point3	pattern_point;
-	t_color		distance;
-	double		distance_from_origin;
-	double		fraction;
 
-	point = tm4mul(pattern.transform, point);
 	obj_point = tm4mul(((t_object *)object)->inv_transform, point);
-	pattern_point = tm4mul(((t_object *)object)->tinv_transform, obj_point);
-	distance = color_sub(pattern.b, pattern.a);
-	distance_from_origin = sqrt(pattern_point.x * pattern_point.x
-			+ pattern_point.y * pattern_point.y
-			+ pattern_point.z * pattern_point.z);
-	fraction = distance_from_origin - (int)floor(distance_from_origin);
-	return (color_add(color_scalar(pattern.a, 1.0f - fraction),
-			color_scalar(distance, fraction)));
+	pattern_point = tm4mul(pattern.transform, obj_point);
+	if (((int)floor(pattern_point.x) + (int)floor(pattern_point.z)) % 2 == 0)
+		return (pattern.a);
+	return (pattern.b);
 }
 
-t_pattern	gradient_pattern(t_color a, t_color b)
+t_pattern	checkboard_pattern(t_color a, t_color b)
 {
-	return ((t_pattern){.a = a, .b = b, .pattern_at_object = gradient_at_object,
+	return ((t_pattern){.a = a, .b = b,
+		.pattern_at_object = checkboard_at_object,
 		.has_pattern = true, .transform = m4default()});
 }

--- a/src/objects/patterns.h
+++ b/src/objects/patterns.h
@@ -24,10 +24,10 @@ t_pattern	pattern(void);
 //	@return The stripe pattern
 t_pattern	stripe_pattern(t_color a, t_color b);
 
-//	gradient_pattern: Create a gradient pattern
+//	checkboard_pattern: Create a checkboard pattern
 //	@param a The first color
 //	@param b The second color
-//	@return The gradient pattern
-t_pattern	gradient_pattern(t_color a, t_color b);
+//	@return The checkboard pattern
+t_pattern	checkboard_pattern(t_color a, t_color b);
 
 #endif


### PR DESCRIPTION
- Fixed fast render that was creating four reflections.
- Increased the maximum number of reflections to ten.
- Replaced gradient_pattern with checkerboard_pattern.
- Refactored image data for improved performance; now directly placing pixels into the image instead of initializing an int** data structure and then filling in the pixels.